### PR TITLE
Fix $time_value vs. $date mixup when combining old & new data

### DIFF
--- a/flusight-baseline.R
+++ b/flusight-baseline.R
@@ -82,7 +82,7 @@ target_tbl_new_form <- readr::read_csv(
   col_types = target_tbl_col_spec
 )
 
-if (min(target_tbl_new_form$time_value) <= as.Date("2022-12-31")) {
+if (min(target_tbl_new_form$date) <= as.Date("2022-12-31")) {
   # The new target table includes old time values spanning back pretty far; we
   # don't need to fill in with old target table values.
   target_tbl <- target_tbl_new_form


### PR DESCRIPTION
Sorry, not sure how this slipped by.  It would always be trying to combine old and new data, even if new data has indeed been updated to include a larger time range.

Should be low-impact or no-impact depending on how far back new reporting goes, due to the combination mechanism for old and new data that favors new data.  Should prevent a warning about `min` outputting `Inf`.